### PR TITLE
display_nvd_data: Initialize vectorString as "N/A"

### DIFF
--- a/sploitscan.py
+++ b/sploitscan.py
@@ -62,7 +62,7 @@ def display_nvd_data(cve_data):
         description = description.replace("\n\n", "")
 
         metrics = cve_item.get("metrics", {}).get("cvssMetricV31", [])
-        baseScore = baseSeverity = "N/A"
+        baseScore = baseSeverity = vectorString = "N/A"
         if metrics:
             cvss_data = metrics[0].get("cvssData", {})
             baseScore = cvss_data.get("baseScore", "N/A")


### PR DESCRIPTION
Fixes `UnboundLocalError`:

```
Traceback (most recent call last):
  File "/pentest/exploits/SploitScan/sploitscan.py", line 424, in <module>
    main(args.cve_ids, args.export)
  File "/pentest/exploits/SploitScan/sploitscan.py", line 350, in main
    display_nvd_data(nvd_data)
  File "/pentest/exploits/SploitScan/sploitscan.py", line 90, in display_nvd_data
    f"{vector_string_label} {vectorString}\n"
                             ^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'vectorString' where it is not associated with a value
```