### PR TITLE
Bind mount to access exported files from container

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ python sploitscan.py CVE-YYYY-NNNNN -e JSON
 
 ```
 docker build -t sploitscan .
-docker run --rm sploitscan CVE-2024-1709
+docker run -v $(pwd):/app --rm sploitscan CVE-2024-1709
 ```
 
 ## 🛡️ Patching Prioritization System


### PR DESCRIPTION
By default, files exported by Docker containers are inaccessible outside the container. This simple command modification allows you to access exported files on your local machine.