### PR TITLE
Correct capitalization in command export value to prevent errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ python sploitscan.py CVE-YYYY-NNNNN CVE-YYYY-NNNNN
 **Optional: Export the results to a JSON or CSV file. Specify the format: 'json' or 'csv'.**
 
 ```bash
-python sploitscan.py CVE-YYYY-NNNNN -e JSON
+python sploitscan.py CVE-YYYY-NNNNN -e json
 ```
 
 **Docker** 


### PR DESCRIPTION
If someone copied the command exactly as it was, it would produce an error. With this simple change in capitalization, we improve user experience.