### PR TITLE
fix manpage-has-bad-whatis-entry

### DIFF
--- a/sploitscan.1
+++ b/sploitscan.1
@@ -1,4 +1,6 @@
 .TH SploitScan
+.SH NAME
+\fBsploitscan\fP - A tool to fetch and display data from NVD and public exploits for given CVE IDs.
 .SH 📜 Description
 .PP
 SploitScan is a powerful and user\-friendly tool designed to streamline the process of identifying exploits for known vulnerabilities and their respective exploitation probability. Empowering cybersecurity professionals with the capability to swiftly identify and apply known and test exploits. It's particularly valuable for professionals seeking to enhance their security measures or develop robust detection strategies against emerging threats.


### PR DESCRIPTION
Hey!
I am sending this change to the manual after updating.

Debian policies require that the manual be started with the SH tag. NAME
based on this:
http://web.mit.edu/ebj/Desktop/ebj/MacData/afs/sipb/project/debathena/lintian/www/tags/manpage-has-bad-whatis-entry.html

Another suggestion would also be to format long text in up to 80 columns.


Hope this helps!

