### PR TITLE
proper packaging with setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,24 @@ $ python sploitscan.py --import-file path/to/yourfile.nessus --type nessus
 $ python sploitscan.py CVE-YYYY-NNNNN -e HTML
 ```
 
-**Docker** 
+**Installation**
+
+```shell
+$ pip install --user  git+https://github.com/xaitax/SploitScan.git # @v0.10 to install a specific realse, branch or commit
+$ sploitscan
+
+███████╗██████╗ ██╗      ██████╗ ██╗████████╗███████╗ ██████╗ █████╗ ███╗   ██╗
+██╔════╝██╔══██╗██║     ██╔═══██╗██║╚══██╔══╝██╔════╝██╔════╝██╔══██╗████╗  ██║
+███████╗██████╔╝██║     ██║   ██║██║   ██║   ███████╗██║     ███████║██╔██╗ ██║
+╚════██║██╔═══╝ ██║     ██║   ██║██║   ██║   ╚════██║██║     ██╔══██║██║╚██╗██║
+███████║██║     ███████╗╚██████╔╝██║   ██║   ███████║╚██████╗██║  ██║██║ ╚████║
+╚══════╝╚═╝     ╚══════╝ ╚═════╝ ╚═╝   ╚═╝   ╚══════╝ ╚═════╝╚═╝  ╚═╝╚═╝  ╚═══╝
+v0.9 / Alexander Hagenah / @xaitax / ah@primepage.de
+
+❌ No CVE IDs provided. Please provide CVE IDs or an import file and type.
+```
+
+**Docker**
 
 ```
 $ docker build -t sploitscan .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,31 +1,28 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=65", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.poetry]
-name = "SploitScan"
+[project]
+name = "sploitscan"
 version = "0.9"
 description = "SploitScan is a sophisticated cybersecurity utility designed to provide detailed information on vulnerabilities and associated exploits."
-authors = ["Alexander Hagenah <ah@primepage.de>"]
-license = "GPL-3.0"
-readme = "README.md"
+authors = [ { name = "Alexander Hagenah", email = "ah@primepage.de" } ]
+license = { file = "LICENSE" }
+dynamic = [ "readme" ]
+dependencies = [
+    "requests~=2.32.2",
+    "jinja2~=3.1.4",
+    "openai~=1.30.2"
+]
+requires-python = ">=3.8"
+scripts.sploitscan = "sploitscan.sploitscan:cli"
 
-[tool.poetry.urls]
+[project.urls]
 homepage = "https://github.com/xaitax/SploitScan"
 repository = "https://github.com/xaitax/SploitScan"
 documentation = "https://github.com/xaitax/SploitScan#readme"
+changelog = "https://github.com/xaitax/SploitScan" 
 
-[tool.poetry.dependencies]
-python = "^3.8"
-requests = "^2.32.2"
-jinja2 = "^3.1.4"
-openai = "^1.30.2"
-
-[tool.setuptools.package-dir]
-sploitscan = "sploitscan"
-
-[tool.setuptools.packages.find]
-where = ["sploitscan"]
-
-[tool.setuptools.package-data]
-sploitscan = ["templates/*.html", "config.json"]
+[tool.setuptools]
+dynamic.readme = { file = [ "README.md" ] }
+package-data.sploitscan = [ "templates/*.html", "config.json" ]

--- a/sploitscan.py
+++ b/sploitscan.py
@@ -1,38 +1,6 @@
 #!/usr/bin/env python3
 
-from sploitscan.sploitscan import main, display_banner
+from sploitscan.sploitscan import cli
 
 if __name__ == "__main__":
-    display_banner()
-    import argparse
-    parser = argparse.ArgumentParser(
-        description="SploitScan: Retrieve and display vulnerability data as well as public exploits for given CVE ID(s)."
-    )
-    parser.add_argument(
-        "cve_ids",
-        type=str,
-        nargs="*",
-        default=[],
-        help="Enter one or more CVE IDs to fetch data. Separate multiple CVE IDs with spaces. Format for each ID: CVE-YYYY-NNNNN. This argument is optional if an import file is provided using the -n option.",
-    )
-    parser.add_argument(
-        "-e",
-        "--export",
-        choices=["json", "JSON", "csv", "CSV", "html", "HTML"],
-        help="Optional: Export the results to a JSON, CSV, or HTML file. Specify the format: 'json', 'csv', or 'html'.",
-    )
-    parser.add_argument(
-        "-t",
-        "--type",
-        choices=["nessus", "nexpose", "openvas", "docker"],
-        help="Specify the type of the import file: 'nessus', 'nexpose', 'openvas' or 'docker'.",
-    )
-    parser.add_argument(
-        "-i",
-        "--import-file",
-        type=str,
-        help="Path to an import file from a vulnerability scanner. If used, CVE IDs can be omitted from the command line arguments.",
-    )
-
-    args = parser.parse_args()
-    main(args.cve_ids, args.export, args.import_file, args.type)
+    cli()

--- a/sploitscan/sploitscan.py
+++ b/sploitscan/sploitscan.py
@@ -886,8 +886,7 @@ def main(cve_ids, export_format=None, import_file=None, import_type=None):
     elif export_format == "html":
         export_to_html(all_results, cve_ids)
 
-
-if __name__ == "__main__":
+def cli():
     display_banner()
     parser = argparse.ArgumentParser(
         description="SploitScan: Retrieve and display vulnerability data as well as public exploits for given CVE ID(s)."
@@ -921,3 +920,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     main(args.cve_ids, args.export, args.import_file, args.type)
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Working packaging with setuptools that can be `pip install`ed and adds console script `sploitscan`.

In a further step, you'll probably want to add CI to automatically build release wheels and release them to pypi.org.

```shell
$ pip install build twine
$ python -m build wheel
$ twine upload build/*.whl ...
```

I don't know why you currently use a mixture of poetry and setuptools (and neither works with recent versions of both).