### PR TITLE
Update pyproject.toml openai version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = [ "readme" ]
 dependencies = [
     "requests~=2.32.2",
     "jinja2~=3.1.4",
-    "openai~=1.30.2"
+    "openai~=1.60.1"
 ]
 requires-python = ">=3.8"
 


### PR DESCRIPTION
I noticed version of openai is updated in `requirements.txt` but the previous version is still used in pyproject.toml.
This fixes it so that it points to the correct version