### PR TITLE
Use local database directory from config instead of fixed sploitscan directory.

### DIFF
--- a/sploitscan/cli.py
+++ b/sploitscan/cli.py
@@ -151,7 +151,6 @@ def main(
     Orchestrate SploitScan workflow for one or more CVE IDs.
     """
     config = load_config(config_path=config_path, debug=debug)
-    print(config)
     all_results: List[Dict[str, Any]] = []
     selected = _selected(methods)
 

--- a/sploitscan/cli.py
+++ b/sploitscan/cli.py
@@ -151,7 +151,7 @@ def main(
     Orchestrate SploitScan workflow for one or more CVE IDs.
     """
     config = load_config(config_path=config_path, debug=debug)
-
+    print(config)
     all_results: List[Dict[str, Any]] = []
     selected = _selected(methods)
 
@@ -375,7 +375,7 @@ def cli() -> None:
         clone_cvelistV5_repo(config=cfg)
 
     if args.keywords:
-        cve_ids = search_cve_by_keywords(args.keywords)
+        cve_ids = search_cve_by_keywords(args.keywords, cfg)
         if not cve_ids:
             raise SystemExit("No valid CVE IDs found for the provided keywords.")
     else:

--- a/sploitscan/search.py
+++ b/sploitscan/search.py
@@ -9,7 +9,7 @@ from .fetchers.common import iter_json_lines
 from .constants import NUCLEI_URL
 
 
-def search_cve_by_keywords(keywords: Iterable[str]) -> List[str]:
+def search_cve_by_keywords(keywords: Iterable[str], cfg: Dict[str, Any]) -> List[str]:
     """
     Aggregate CVE IDs matching all keywords across:
     - Local cvelistV5 JSON database (if present)
@@ -22,7 +22,7 @@ def search_cve_by_keywords(keywords: Iterable[str]) -> List[str]:
     results: Set[str] = set()
 
     # Local grep
-    local_cve_ids = grep_local_db(kws)
+    local_cve_ids = grep_local_db(kws, config=cfg)
     if local_cve_ids:
         results.update(local_cve_ids)
 


### PR DESCRIPTION
This PR enables sploitscan to use already checkout cvelistV5 directory via a configuration key "local_database_dir". So sploitscan can use that as source and not the always fixed directory.